### PR TITLE
Enhance team spotlight, SEO, and checkout add-ons

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -42,6 +42,10 @@ img {
   display: block;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;
@@ -415,8 +419,8 @@ img {
 }
 .grid-3 {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
   gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 .grid-2 {
   display: grid;
@@ -808,6 +812,12 @@ textarea::placeholder {
   gap: 12px;
 }
 
+.service-chip__header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .service-chip h4 {
   margin: 0;
 }
@@ -817,6 +827,25 @@ textarea::placeholder {
   color: var(--muted);
 }
 
+.service-chip__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.service-chip__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--brand) 18%, var(--card) 82%);
+  color: var(--brand);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
 .service-chip__price {
   font-weight: 600;
   color: var(--brand);
@@ -824,7 +853,31 @@ textarea::placeholder {
 
 .service-chip .btn {
   width: fit-content;
-  margin-top: 12px;
+}
+
+.service-chip__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  margin-top: 4px;
+}
+
+.service-chip__actions .btn {
+  margin-top: 0;
+}
+
+.service-chip__actions .detail-link {
+  color: var(--brand);
+  font-weight: 600;
+}
+
+.service-chip__toggle {
+  cursor: pointer;
+}
+
+.service-chip__toggle[aria-pressed="true"] {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--brand) 25%, transparent);
 }
 
 .service-option {
@@ -878,6 +931,40 @@ textarea::placeholder {
   border: 1px solid var(--border);
   padding: 16px;
   border-radius: 12px;
+}
+.order-addons {
+  border-top: 1px solid var(--border);
+  margin-top: 16px;
+  padding-top: 12px;
+}
+.order-addons--list {
+  display: grid;
+  gap: 12px;
+}
+.order-addons--list h3 {
+  margin: 0;
+  font-size: 18px;
+}
+.order-addons--list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+.order-addons--list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+  font-size: 15px;
+}
+.order-addons--list li span {
+  color: var(--muted);
+  font-size: 14px;
+}
+.order-addons--empty {
+  margin-bottom: 0;
 }
 .order-details {
   background: var(--card);
@@ -1100,6 +1187,45 @@ textarea::placeholder {
 .detail-card ul {
   margin: 0;
   padding-left: 20px;
+  color: var(--muted);
+}
+
+.detail-card--team {
+  gap: 16px;
+}
+
+.team-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.team-list li {
+  display: grid;
+  gap: 6px;
+}
+
+.team-list strong {
+  font-size: 1rem;
+}
+
+.team-member__role {
+  display: block;
+  color: var(--brand);
+  font-weight: 600;
+  margin-top: 2px;
+}
+
+.team-member__location {
+  display: block;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.team-list p {
+  margin: 0;
   color: var(--muted);
 }
 

--- a/assets/js/core/meta.js
+++ b/assets/js/core/meta.js
@@ -12,6 +12,18 @@ export function updateHeadMeta(data, pageKey) {
   setMeta("property", "og:description", description);
   setMeta("name", "twitter:title", title);
   setMeta("name", "twitter:description", description);
+  const siteName = data.seo?.siteName || data.org?.name || "";
+  if (siteName) setMeta("property", "og:site_name", siteName);
+  const author = data.seo?.author || data.org?.name || "";
+  if (author) setMeta("name", "author", author);
+  const robots = data.seo?.robots;
+  if (robots) setMeta("name", "robots", robots);
+  const themeColor = data.seo?.themeColor;
+  if (themeColor) setMeta("name", "theme-color", themeColor);
+  const twitterSite = data.seo?.twitterHandle;
+  if (twitterSite) setMeta("name", "twitter:site", twitterSite);
+  const twitterCreator = data.seo?.twitterCreator || twitterSite;
+  if (twitterCreator) setMeta("name", "twitter:creator", twitterCreator);
 
   const canonical = document.querySelector("link[rel='canonical']");
   const url = buildUrl(meta.path || pageKey, data.org?.url);

--- a/assets/js/core/storage.js
+++ b/assets/js/core/storage.js
@@ -1,3 +1,5 @@
+const SELECTED_SERVICES_KEY = "selectedServices";
+
 export function savePlanSelection(plan) {
   if (!plan) return;
   const payload = {
@@ -13,6 +15,33 @@ export function getSelectedPlan() {
   } catch (error) {
     return null;
   }
+}
+
+export function getSelectedServices() {
+  try {
+    return JSON.parse(localStorage.getItem(SELECTED_SERVICES_KEY) || "[]");
+  } catch (error) {
+    return [];
+  }
+}
+
+export function setSelectedServices(services = []) {
+  const unique = Array.from(
+    new Set((Array.isArray(services) ? services : []).filter(Boolean))
+  );
+  localStorage.setItem(SELECTED_SERVICES_KEY, JSON.stringify(unique));
+  return unique;
+}
+
+export function toggleSelectedService(id) {
+  if (!id) return getSelectedServices();
+  const current = new Set(getSelectedServices());
+  if (current.has(id)) {
+    current.delete(id);
+  } else {
+    current.add(id);
+  }
+  return setSelectedServices([...current]);
 }
 
 export function getLastOrder() {

--- a/assets/js/core/utils.js
+++ b/assets/js/core/utils.js
@@ -11,8 +11,14 @@ export function qsa(selector, scope = document) {
 }
 
 export function setMeta(attr, name, content) {
-  const el = document.querySelector(`meta[${attr}='${name}']`);
-  if (el && content) {
+  if (typeof name !== "string") return;
+  let el = document.querySelector(`meta[${attr}='${name}']`);
+  if (!el) {
+    el = document.createElement("meta");
+    el.setAttribute(attr, name);
+    document.head.appendChild(el);
+  }
+  if (typeof content === "string") {
     el.setAttribute("content", content);
   }
 }

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -27,6 +27,12 @@ window.DATA = {
   seo: {
     defaultKeywords:
       "secure web development, security-first developers, seo optimisation services, managed web maintenance, ecommerce security, australia web agency",
+    siteName: "Secure IT Developers",
+    author: "Secure IT Developers",
+    robots: "index, follow",
+    twitterHandle: "@secureitdev",
+    twitterCreator: "@pasanbuilds",
+    themeColor: "#0b1d3a",
     ogImage: "assets/img/placeholder-growth.svg",
   },
   navigation: [
@@ -123,8 +129,8 @@ window.DATA = {
     },
     {
       id: "sunera-ranasooriya",
-      name: "Sunera Ranasooriya",
-      role: "Cyber Security Specialist",
+      name: "Sunera Ranasooroya",
+      role: "Cybersecurity Specialist",
       location: "Colombo, Sri Lanka",
       bio:
         "Sunera leads threat modelling and incident readiness for regulated teams, drawing on 8+ years across telecom and fintech SOC leadership.",
@@ -325,9 +331,9 @@ window.DATA = {
         ],
       },
       spotlight: {
-        heading: "Meet your lead engineer",
+        heading: "This is our team",
         copy:
-          "Work directly with Pasan from strategy to deployment—no hand-offs, just a founder-level partner shipping alongside you.",
+          "Partner with founder-engineer Pasan Rathnayake and cybersecurity specialist Sunera Ranasooroya from discovery to deployment—no hand-offs, just leadership embedded in every sprint.",
         memberId: "pasan-rathnayake",
       },
       contact: {
@@ -343,7 +349,7 @@ window.DATA = {
       meta: {
         title: "About Secure IT Developers",
         description:
-          "Meet the Melbourne studio led by Pasan Rathnayake, blending security engineering, product strategy, and design to ship dependable digital products.",
+          "Inside the Melbourne studio led by Pasan Rathnayake, blending security engineering, product strategy, and design to ship dependable digital products.",
         path: "about.html",
         keywords:
           "secure development team, security design sprints, australian dev studio, devops automation partner",
@@ -781,6 +787,8 @@ window.DATA = {
         description:
           "Dive deeper into our engagements and specialist services, including deliverables, pricing guidance, and recommended add-ons.",
         path: "detail.html",
+        keywords:
+          "secure it developers engagement details, security focused service breakdown, web app package inclusions, cybersecurity add ons",
         image: "assets/img/placeholder-team.svg",
       },
     },
@@ -803,6 +811,9 @@ window.DATA = {
         description:
           "Review the plan you selected from Secure IT Developers before proceeding to payment.",
         path: "checkout.html",
+        keywords:
+          "secure it developers checkout, confirm web development package, add services to quote, security focused engagement review",
+        image: "assets/img/placeholder-ops.svg",
       },
       message:
         "Need adjustments or a tailored engagement? Contact us and we'll customise the deliverables before you pay.",
@@ -813,6 +824,9 @@ window.DATA = {
         description:
           "Enter billing details to complete your Secure IT Developers engagement.",
         path: "payment.html",
+        keywords:
+          "secure it developers payment, pay for cybersecurity project, secure billing portal, web app development invoice",
+        image: "assets/img/placeholder-growth.svg",
       },
       message: "All transactions are encrypted and reviewed by our finance team within one business day.",
     },
@@ -822,6 +836,9 @@ window.DATA = {
         description:
           "Your Secure IT Developers engagement is confirmed. We'll reach out with next steps.",
         path: "success.html",
+        keywords:
+          "secure it developers payment success, project kickoff confirmation, cybersecurity engagement onboarding",
+        image: "assets/img/placeholder-team.svg",
       },
       heading: "Payment confirmed",
       body:
@@ -837,6 +854,9 @@ window.DATA = {
         description:
           "Something went wrong while processing your payment with Secure IT Developers.",
         path: "failed.html",
+        keywords:
+          "secure it developers payment failed, retry secure payment, billing support cybersecurity agency",
+        image: "assets/img/placeholder-ops.svg",
       },
       heading: "Payment unsuccessful",
       body:

--- a/assets/js/renderers/checkout.js
+++ b/assets/js/renderers/checkout.js
@@ -1,41 +1,101 @@
 import { byId, formatCurrency } from "../core/utils.js";
-import { getSelectedPlan } from "../core/storage.js";
+import {
+  getSelectedPlan,
+  getSelectedServices,
+  setSelectedServices,
+  toggleSelectedService,
+} from "../core/storage.js";
 import { renderOtherServices } from "./shared.js";
 
 export function renderCheckoutPage(data) {
   const plan = getSelectedPlan();
   const info = byId("messageInfo");
-  if (info && !plan) {
-    info.textContent = "No plan selected. Please choose a package from pricing.";
+  if (info) {
+    info.textContent = plan
+      ? data.pages?.checkout?.message || ""
+      : "No plan selected. Please choose a package from pricing.";
   }
   const summaryTarget = byId("orderSummary");
-  if (summaryTarget) {
+  const servicesCatalog = data.serviceCatalog || [];
+  let selectedServiceIds = getSelectedServices();
+  const validSelected = selectedServiceIds.filter((id) =>
+    servicesCatalog.some((service) => service.id === id)
+  );
+  if (validSelected.length !== selectedServiceIds.length) {
+    selectedServiceIds = setSelectedServices(validSelected);
+  }
+
+  const updateSummary = () => {
+    if (!summaryTarget) return;
     if (!plan) {
       summaryTarget.innerHTML =
         '<p>No plan selected. <a href="pricing.html">Choose a plan</a>.</p>';
-    } else {
-      summaryTarget.innerHTML = `
-        <h2>${plan.name}</h2>
-        <p class="price">${formatCurrency(plan.price, plan.currency)}</p>
-        <p class="muted">Selected at ${new Date(plan.time).toLocaleString()}</p>
-      `;
+      return;
     }
-  }
+    const selectedDetails = selectedServiceIds
+      .map((id) => servicesCatalog.find((service) => service.id === id))
+      .filter(Boolean);
+    const addons = selectedDetails.length
+      ? `<div class="order-addons order-addons--list"><h3>Added services</h3><ul>${selectedDetails
+          .map((service) => {
+            const priceLabel = service.priceLabel
+              ? `<span>${service.priceLabel}</span>`
+              : "";
+            return `<li><strong>${service.title}</strong>${priceLabel}</li>`;
+          })
+          .join("")}</ul></div>`
+      : '<p class="order-addons order-addons--empty muted">No extra services selected yet. Add services below to include them in your quote.</p>';
+    summaryTarget.innerHTML = `
+      <h2>${plan.name}</h2>
+      <p class="price">${formatCurrency(plan.price, plan.currency)}</p>
+      <p class="muted">Selected at ${new Date(plan.time).toLocaleString()}</p>
+      ${addons}
+    `;
+  };
+
+  updateSummary();
 
   const relatedTarget = byId("relatedServices");
   const relatedSection = document.querySelector(".related-services");
   if (relatedSection) {
     relatedSection.hidden = !plan;
+    const heading = relatedSection.querySelector("h2");
+    if (heading && plan) heading.textContent = "Add services to your quote";
   }
-  if (relatedTarget) {
-    const planServices = JSON.parse(localStorage.getItem("selectedServices") || "[]");
-    const services = (data.serviceCatalog || []).filter((service) =>
-      !planServices.length ? true : planServices.includes(service.id)
-    );
-    if (!services.length) {
-      relatedTarget.innerHTML = "<p class=\"muted\">Browse our standalone services to add specialist support.</p>";
-    } else {
-      renderOtherServices(relatedTarget, services);
+
+  const renderServices = () => {
+    if (!relatedTarget) return;
+    if (!plan) {
+      relatedTarget.innerHTML =
+        '<p class="muted">Select a package to see available add-on services.</p>';
+      return;
     }
-  }
+    if (!servicesCatalog.length) {
+      relatedTarget.innerHTML =
+        '<p class="muted">Additional services will appear here once configured.</p>';
+      return;
+    }
+    const recommendedSet = new Set(plan.recommendedServices || []);
+    const sorted = [...servicesCatalog].sort((a, b) => {
+      const aRecommended = recommendedSet.has(a.id) ? 0 : 1;
+      const bRecommended = recommendedSet.has(b.id) ? 0 : 1;
+      if (aRecommended !== bRecommended) return aRecommended - bRecommended;
+      return a.title.localeCompare(b.title);
+    });
+    renderOtherServices(relatedTarget, sorted, {
+      selectable: true,
+      selectedIds: selectedServiceIds,
+      recommendedIds: recommendedSet,
+      detailLink: true,
+      linkLabel: "View service details",
+      onToggle: (serviceId) => {
+        selectedServiceIds = toggleSelectedService(serviceId);
+        updateSummary();
+        renderServices();
+      },
+    });
+  };
+
+  renderServices();
+
 }

--- a/assets/js/renderers/pricing.js
+++ b/assets/js/renderers/pricing.js
@@ -1,5 +1,5 @@
 import { byId, formatCurrency } from "../core/utils.js";
-import { savePlanSelection } from "../core/storage.js";
+import { savePlanSelection, setSelectedServices } from "../core/storage.js";
 import { renderOtherServices } from "./shared.js";
 
 export function renderPricingPage(data) {
@@ -99,8 +99,9 @@ export function renderPricingPage(data) {
           name: `${group.label} – ${plan.label}`,
           price: Number(plan.price),
           currency: plan.currency,
+          recommendedServices: plan.recommendedServices || [],
         });
-        localStorage.setItem("selectedServices", JSON.stringify(plan.recommendedServices || []));
+        setSelectedServices(plan.recommendedServices || []);
         window.location.href = "checkout.html";
       });
       section.appendChild(card);


### PR DESCRIPTION
## Summary
- enrich the centralized SEO configuration with site metadata and refresh copy to highlight the expanded security team
- surface both core team members in the detail sidebar and improve reusable service cards with selectable add-on support
- allow checkout visitors to build a quote with multiple add-on services while updating styles to highlight selections and added services

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d492271ee48333aa63186b71b84464