### PR TITLE
Add customer auth and cart features with seed database schema

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -144,6 +144,58 @@ img {
   gap: 12px;
 }
 
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.nav-actions__slot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.nav-user {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.cart-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+}
+
+.cart-toggle__icon {
+  font-size: 1rem;
+}
+
+.cart-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  background: var(--brand);
+  color: #fff;
+  font-size: 0.75rem;
+  padding: 0 6px;
+}
+
+.mobile-auth {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.mobile-auth__greeting {
+  margin: 0;
+  color: var(--muted);
+}
+
 .nav-toggle {
   display: none;
   background: transparent;
@@ -262,5 +314,10 @@ body.nav-open .nav-toggle__bar:nth-child(3) {
     display: inline-flex;
     flex-direction: column;
     justify-content: center;
+  }
+  .nav-actions {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 8px;
   }
 }

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -771,6 +771,12 @@ textarea::placeholder {
   margin-top: 0;
 }
 
+.service-chip__cart {
+  background: transparent;
+  border: 1px dashed var(--border);
+  color: var(--text);
+}
+
 .service-chip__actions .detail-link {
   color: var(--brand);
   font-weight: 600;
@@ -1359,6 +1365,19 @@ textarea::placeholder {
   color: var(--muted);
 }
 
+.detail-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  margin-top: 20px;
+}
+
+.detail-card__actions .detail-link {
+  color: var(--brand);
+  font-weight: 600;
+}
+
 .detail-card--team {
   gap: 16px;
 }
@@ -1677,4 +1696,250 @@ textarea::placeholder {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 20px;
+}
+
+/* Auth pages */
+.auth-page {
+  min-height: calc(100vh - 240px);
+  display: grid;
+  align-items: start;
+  justify-content: center;
+  padding: 48px 24px 72px;
+}
+
+.auth-card {
+  max-width: 520px;
+  background: color-mix(in srgb, var(--card) 90%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 32px;
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 20px;
+}
+
+.auth-card h1 {
+  margin: 0;
+}
+
+.auth-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.auth-form {
+  display: grid;
+  gap: 16px;
+}
+
+.form-status {
+  margin: 0;
+  min-height: 20px;
+}
+
+.auth-switch {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.auth-switch a {
+  color: var(--brand);
+  font-weight: 600;
+}
+
+.auth-db {
+  font-size: 0.85rem;
+  color: var(--muted);
+  background: color-mix(in srgb, var(--card) 75%, transparent);
+  border: 1px dashed var(--border);
+  border-radius: 12px;
+  padding: 12px 16px;
+}
+
+.auth-db__list {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.auth-db__list strong {
+  color: var(--text);
+}
+
+@media (max-width: 640px) {
+  .auth-card {
+    padding: 24px;
+  }
+  .auth-page {
+    padding: 32px 16px 56px;
+  }
+}
+
+/* Cart drawer and status toasts */
+.cart-drawer {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  display: flex;
+  justify-content: flex-end;
+  z-index: 30;
+}
+
+.cart-drawer__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.4);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.cart-drawer__panel {
+  position: relative;
+  width: min(420px, 90vw);
+  background: var(--bg);
+  border-left: 1px solid var(--border);
+  box-shadow: -12px 0 24px rgba(15, 23, 42, 0.25);
+  transform: translateX(100%);
+  transition: transform 0.35s ease;
+  display: flex;
+  flex-direction: column;
+  max-height: 100vh;
+}
+
+.cart-drawer.is-open {
+  pointer-events: auto;
+}
+
+.cart-drawer.is-open .cart-drawer__overlay {
+  opacity: 1;
+}
+
+.cart-drawer.is-open .cart-drawer__panel {
+  transform: translateX(0);
+}
+
+.cart-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--border);
+}
+
+.cart-drawer__close {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  width: 34px;
+  height: 34px;
+  font-size: 1.4rem;
+  cursor: pointer;
+}
+
+.cart-drawer__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 24px;
+  display: grid;
+  align-content: start;
+  gap: 16px;
+}
+
+.cart-empty {
+  text-align: center;
+  margin: 40px 0;
+}
+
+.cart-line-items {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.cart-line-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.cart-line-item:last-child {
+  border-bottom: 0;
+}
+
+.cart-line-item__meta {
+  display: block;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.cart-line-item__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.cart-line-item__price {
+  font-weight: 600;
+}
+
+.cart-drawer__footer {
+  padding: 20px 24px;
+  border-top: 1px solid var(--border);
+  display: grid;
+  gap: 12px;
+}
+
+.cart-drawer__total {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 1.1rem;
+}
+
+#cartCheckoutButton.is-disabled {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.cart-status,
+.auth-status {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  background: var(--text);
+  color: var(--bg);
+  padding: 12px 18px;
+  border-radius: 999px;
+  box-shadow: var(--shadow);
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: 35;
+}
+
+.cart-status.is-visible,
+.auth-status.is-visible {
+  opacity: 0.95;
+  transform: translateY(0);
+}
+
+@media (max-width: 640px) {
+  .cart-drawer__panel {
+    width: 100%;
+  }
+  .cart-status,
+  .auth-status {
+    left: 16px;
+    right: 16px;
+    bottom: 16px;
+    border-radius: 12px;
+    text-align: center;
+  }
 }

--- a/assets/js/core/auth.js
+++ b/assets/js/core/auth.js
@@ -1,0 +1,437 @@
+import { byId } from "./utils.js";
+
+const DEFAULT_NAMESPACE = "secure_it";
+const DEFAULT_SESSION_TTL_HOURS = 72;
+const AUTH_CHANGE_EVENT = "auth:change";
+let authStatusTimeout;
+
+function getConfig() {
+  return window.ENV?.auth || {};
+}
+
+function getNamespace() {
+  const ns = getConfig().storageNamespace || window.ENV?.database?.name;
+  return (ns || DEFAULT_NAMESPACE).replace(/[^a-z0-9_\-]/gi, "_");
+}
+
+function getSessionTtlMs() {
+  const hours = Number(getConfig().sessionTtlHours || DEFAULT_SESSION_TTL_HOURS);
+  return Number.isFinite(hours) ? hours * 60 * 60 * 1000 : DEFAULT_SESSION_TTL_HOURS * 60 * 60 * 1000;
+}
+
+function storageKeys() {
+  const ns = getNamespace();
+  return {
+    customers: `${ns}_customers`,
+    session: `${ns}_session`,
+  };
+}
+
+function loadCustomers() {
+  const { customers } = storageKeys();
+  try {
+    const raw = localStorage.getItem(customers);
+    return raw ? JSON.parse(raw) : [];
+  } catch (error) {
+    console.warn("Unable to parse stored customers", error);
+    return [];
+  }
+}
+
+function saveCustomers(customers) {
+  const { customers: key } = storageKeys();
+  localStorage.setItem(key, JSON.stringify(customers || []));
+}
+
+function loadSession() {
+  const { session } = storageKeys();
+  try {
+    const raw = localStorage.getItem(session);
+    return raw ? JSON.parse(raw) : null;
+  } catch (error) {
+    console.warn("Unable to parse stored session", error);
+    return null;
+  }
+}
+
+function saveSession(session) {
+  const { session: key } = storageKeys();
+  localStorage.setItem(key, JSON.stringify(session));
+}
+
+function clearSession() {
+  const { session } = storageKeys();
+  localStorage.removeItem(session);
+}
+
+function hashPassword(password, salt) {
+  const data = `${password}::${salt}`;
+  let hash = 0;
+  for (let i = 0; i < data.length; i += 1) {
+    hash = (hash << 5) - hash + data.charCodeAt(i);
+    hash |= 0;
+  }
+  return btoa(String(hash));
+}
+
+function findCustomerByEmail(email) {
+  return loadCustomers().find(
+    (customer) => customer.email.toLowerCase() === email.toLowerCase().trim()
+  );
+}
+
+function buildSession(customer) {
+  return {
+    id: `session_${customer.id}`,
+    customerId: customer.id,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function sessionExpired(session) {
+  if (!session?.createdAt) return true;
+  const created = new Date(session.createdAt).getTime();
+  if (Number.isNaN(created)) return true;
+  const expiresAt = created + getSessionTtlMs();
+  return Date.now() > expiresAt;
+}
+
+function notifyAuthChange(customer) {
+  document.dispatchEvent(
+    new CustomEvent(AUTH_CHANGE_EVENT, { detail: { customer } })
+  );
+}
+
+export function getCurrentCustomer() {
+  const session = loadSession();
+  if (!session) {
+    return null;
+  }
+  if (sessionExpired(session)) {
+    clearSession();
+    notifyAuthChange(null);
+    return null;
+  }
+  const customer = loadCustomers().find((item) => item.id === session.customerId);
+  if (!customer) {
+    clearSession();
+    notifyAuthChange(null);
+    return null;
+  }
+  return {
+    id: customer.id,
+    name: customer.name,
+    email: customer.email,
+  };
+}
+
+export function logoutCustomer() {
+  clearSession();
+  notifyAuthChange(null);
+}
+
+function createCustomer({ name, email, password }) {
+  const trimmedEmail = email.trim();
+  const existing = findCustomerByEmail(trimmedEmail);
+  if (existing) {
+    return { ok: false, error: "An account with that email already exists." };
+  }
+  const saltSource =
+    typeof crypto !== "undefined" && crypto.getRandomValues
+      ? crypto.getRandomValues(new Uint32Array(1))[0]
+      : Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+  const salt = saltSource.toString(16);
+  const passwordHash = hashPassword(password, salt);
+  const customers = loadCustomers();
+  const customer = {
+    id: `cust_${Date.now()}`,
+    name: name.trim(),
+    email: trimmedEmail,
+    salt,
+    passwordHash,
+    createdAt: new Date().toISOString(),
+  };
+  customers.push(customer);
+  saveCustomers(customers);
+  return { ok: true, customer };
+}
+
+function authenticate({ email, password }) {
+  const customer = findCustomerByEmail(email);
+  if (!customer) {
+    return { ok: false, error: "No account found for that email." };
+  }
+  const passwordHash = hashPassword(password, customer.salt);
+  if (passwordHash !== customer.passwordHash) {
+    return { ok: false, error: "Incorrect password. Please try again." };
+  }
+  return { ok: true, customer };
+}
+
+function ensureSlots() {
+  const wrap = document.querySelector(".nav-wrap");
+  if (!wrap) return {};
+  let actions = wrap.querySelector(".nav-actions");
+  if (!actions) {
+    actions = document.createElement("div");
+    actions.className = "nav-actions";
+    wrap.appendChild(actions);
+  }
+  let cartSlot = actions.querySelector("[data-cart-slot]");
+  if (!cartSlot) {
+    cartSlot = document.createElement("div");
+    cartSlot.className = "nav-actions__slot nav-actions__slot--cart";
+    cartSlot.setAttribute("data-cart-slot", "");
+    actions.appendChild(cartSlot);
+  }
+  let authSlot = actions.querySelector("[data-auth-slot]");
+  if (!authSlot) {
+    authSlot = document.createElement("div");
+    authSlot.className = "nav-actions__slot nav-actions__slot--auth";
+    authSlot.setAttribute("data-auth-slot", "");
+    actions.appendChild(authSlot);
+  }
+  return { actions, cartSlot, authSlot };
+}
+
+function renderMobileAuth(customer) {
+  const mobileNav = document.getElementById("mobileNav");
+  if (!mobileNav) return;
+  mobileNav.querySelectorAll("[data-auth-nav]").forEach((item) => item.remove());
+  const item = document.createElement(customer ? "div" : "a");
+  item.setAttribute("data-auth-nav", "");
+  item.className = "mobile-auth";
+  if (customer) {
+    item.innerHTML = `
+      <p class="mobile-auth__greeting">Signed in as ${customer.name}</p>
+      <button type="button" class="btn btn-ghost" data-auth-action="logout">Log out</button>
+    `;
+  } else {
+    item.href = "login.html";
+    item.classList.add("btn");
+    item.textContent = "Customer login";
+  }
+  mobileNav.appendChild(item);
+}
+
+function ensureAuthStatus() {
+  let status = byId("authStatus");
+  if (!status) {
+    status = document.createElement("div");
+    status.id = "authStatus";
+    status.className = "auth-status";
+    status.setAttribute("role", "status");
+    status.setAttribute("aria-live", "polite");
+    document.body.appendChild(status);
+  }
+  return status;
+}
+
+function showAuthStatus(message) {
+  const status = ensureAuthStatus();
+  status.textContent = message;
+  status.classList.add("is-visible");
+  clearTimeout(authStatusTimeout);
+  authStatusTimeout = setTimeout(() => {
+    status.classList.remove("is-visible");
+  }, 2400);
+}
+
+function renderAuthControls() {
+  const { authSlot } = ensureSlots();
+  if (!authSlot) return;
+  const customer = getCurrentCustomer();
+  authSlot.innerHTML = "";
+  if (customer) {
+    const firstName = (customer.name || "Customer").split(" ")[0];
+    const greeting = document.createElement("span");
+    greeting.className = "nav-user";
+    greeting.textContent = `Hi, ${firstName}`;
+    authSlot.appendChild(greeting);
+    const logout = document.createElement("button");
+    logout.type = "button";
+    logout.className = "btn btn-ghost";
+    logout.setAttribute("data-auth-action", "logout");
+    logout.textContent = "Log out";
+    authSlot.appendChild(logout);
+  } else {
+    const login = document.createElement("a");
+    login.className = "btn btn-ghost";
+    login.href = "login.html";
+    login.textContent = "Log in";
+    authSlot.appendChild(login);
+    const signup = document.createElement("a");
+    signup.className = "btn";
+    signup.href = "signup.html";
+    signup.textContent = "Create account";
+    authSlot.appendChild(signup);
+  }
+  renderMobileAuth(customer);
+}
+
+function safeRedirect(target) {
+  if (!target) return null;
+  try {
+    const url = new URL(target, window.location.origin);
+    if (url.origin !== window.location.origin) return null;
+    return `${url.pathname.replace(/^\//, "")}${url.search}${url.hash}`;
+  } catch (error) {
+    return null;
+  }
+}
+
+function getRedirectParam() {
+  const params = new URLSearchParams(window.location.search);
+  return safeRedirect(params.get("redirect"));
+}
+
+function handleSignup() {
+  const form = byId("signupForm");
+  if (!form) return;
+  const status = byId("signupStatus");
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    if (typeof form.reportValidity === "function" && !form.reportValidity()) {
+      return;
+    }
+    const name = form.fullname?.value.trim();
+    const email = form.email?.value.trim();
+    const password = form.password?.value || "";
+    const confirm = form.confirm?.value || "";
+    if (!name) {
+      if (status) status.textContent = "Please provide your full name.";
+      return;
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email || "")) {
+      if (status) status.textContent = "Enter a valid email address.";
+      return;
+    }
+    if (password.length < 8) {
+      if (status) status.textContent = "Password must be at least 8 characters.";
+      return;
+    }
+    if (password !== confirm) {
+      if (status) status.textContent = "Passwords do not match.";
+      return;
+    }
+    const result = createCustomer({ name, email, password });
+    if (!result.ok) {
+      if (status) status.textContent = result.error;
+      return;
+    }
+    const session = buildSession(result.customer);
+    saveSession(session);
+    notifyAuthChange({
+      id: result.customer.id,
+      name: result.customer.name,
+      email: result.customer.email,
+    });
+    if (status) status.textContent = "Account created! Redirecting…";
+    const redirect = getRedirectParam() || "checkout.html";
+    setTimeout(() => {
+      window.location.href = redirect;
+    }, 800);
+  });
+}
+
+function handleLogin() {
+  const form = byId("loginForm");
+  if (!form) return;
+  const status = byId("loginStatus");
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    if (typeof form.reportValidity === "function" && !form.reportValidity()) {
+      return;
+    }
+    const email = form.email?.value.trim();
+    const password = form.password?.value || "";
+    const result = authenticate({ email, password });
+    if (!result.ok) {
+      if (status) status.textContent = result.error;
+      return;
+    }
+    const session = buildSession(result.customer);
+    saveSession(session);
+    notifyAuthChange({
+      id: result.customer.id,
+      name: result.customer.name,
+      email: result.customer.email,
+    });
+    if (status) status.textContent = "Login successful! Redirecting…";
+    const redirect = getRedirectParam() || "pricing.html";
+    setTimeout(() => {
+      window.location.href = redirect;
+    }, 600);
+  });
+}
+
+function handleLogoutClicks() {
+  document.addEventListener("click", (event) => {
+    const trigger = event.target.closest("[data-auth-action='logout']");
+    if (!trigger) return;
+    event.preventDefault();
+    logoutCustomer();
+    showAuthStatus("You have been signed out.");
+    if (/checkout|payment/.test(window.location.pathname)) {
+      window.location.href = "login.html?redirect=checkout.html";
+    }
+  });
+}
+
+function renderDatabaseNotice() {
+  const notice = byId("dbConfigNotice");
+  if (!notice) return;
+  const db = window.ENV?.database;
+  notice.innerHTML = "";
+  if (!db) {
+    notice.textContent =
+      "Set database credentials in assets/js/env.js before deploying.";
+    return;
+  }
+  const list = document.createElement("ul");
+  list.className = "auth-db__list";
+  const items = [
+    { label: "Host", value: db.host || "not set" },
+    { label: "Port", value: db.port ?? "not set" },
+    { label: "Database", value: db.name || "not set" },
+    { label: "User", value: db.user || "not set" },
+  ];
+  if (db.passwordEnvVar) {
+    items.push({ label: "Password env var", value: db.passwordEnvVar });
+  }
+  items.forEach((item) => {
+    const li = document.createElement("li");
+    const label = document.createElement("strong");
+    label.textContent = `${item.label}:`;
+    const value = document.createElement("span");
+    value.textContent = String(item.value);
+    li.appendChild(label);
+    li.appendChild(document.createTextNode(" "));
+    li.appendChild(value);
+    list.appendChild(li);
+  });
+  notice.appendChild(list);
+}
+
+export function requireAuth(redirectTo) {
+  const customer = getCurrentCustomer();
+  if (customer) return customer;
+  const target = safeRedirect(redirectTo) || "checkout.html";
+  const url = new URL("login.html", window.location.origin);
+  url.searchParams.set("redirect", target);
+  window.location.href = `${url.pathname}${url.search}`;
+  return null;
+}
+
+export function initAuth() {
+  ensureSlots();
+  renderAuthControls();
+  renderDatabaseNotice();
+  handleSignup();
+  handleLogin();
+  handleLogoutClicks();
+  document.addEventListener(AUTH_CHANGE_EVENT, renderAuthControls);
+  document.addEventListener(AUTH_CHANGE_EVENT, renderDatabaseNotice);
+}
+
+*** End of File

--- a/assets/js/core/cart.js
+++ b/assets/js/core/cart.js
@@ -1,0 +1,281 @@
+import { byId, formatCurrency } from "./utils.js";
+import { getSelectedServices, setSelectedServices } from "./storage.js";
+
+const CART_DRAWER_ID = "cartDrawer";
+const CART_COUNT_ID = "cartCount";
+const CART_ITEMS_ID = "cartItems";
+const CART_TOTAL_ID = "cartTotal";
+const CART_STATUS_ID = "cartStatus";
+const SELECTED_EVENT = "cart:selectedServices";
+
+let serviceIndex = new Map();
+let cartIds = new Set();
+let statusTimeout;
+let billingCurrency = "AUD";
+
+function ensureCartToggle() {
+  const cartSlot = document.querySelector("[data-cart-slot]");
+  if (!cartSlot) return null;
+  let toggle = cartSlot.querySelector("#cartToggle");
+  if (!toggle) {
+    toggle = document.createElement("button");
+    toggle.id = "cartToggle";
+    toggle.type = "button";
+    toggle.className = "btn btn-ghost cart-toggle";
+    toggle.setAttribute("aria-haspopup", "dialog");
+    toggle.setAttribute("aria-expanded", "false");
+    toggle.setAttribute("aria-label", "View cart");
+    toggle.innerHTML = `
+      <span class="cart-toggle__icon" aria-hidden="true">🛒</span>
+      <span class="cart-toggle__label">Cart</span>
+      <span class="cart-count" id="${CART_COUNT_ID}" aria-live="polite">0</span>
+    `;
+    cartSlot.appendChild(toggle);
+  }
+  toggle.addEventListener("click", () => {
+    const drawer = byId(CART_DRAWER_ID);
+    if (!drawer) return;
+    if (drawer.classList.contains("is-open")) {
+      closeDrawer();
+    } else {
+      openDrawer();
+    }
+  });
+  return toggle;
+}
+
+function ensureStatusElement() {
+  let status = byId(CART_STATUS_ID);
+  if (!status) {
+    status = document.createElement("div");
+    status.id = CART_STATUS_ID;
+    status.className = "cart-status";
+    status.setAttribute("role", "status");
+    status.setAttribute("aria-live", "polite");
+    document.body.appendChild(status);
+  }
+  return status;
+}
+
+function showStatus(message) {
+  const status = ensureStatusElement();
+  if (!status) return;
+  status.textContent = message;
+  status.classList.add("is-visible");
+  clearTimeout(statusTimeout);
+  statusTimeout = setTimeout(() => {
+    status.classList.remove("is-visible");
+  }, 2400);
+}
+
+function buildDrawer() {
+  let drawer = byId(CART_DRAWER_ID);
+  if (!drawer) {
+    drawer = document.createElement("div");
+    drawer.id = CART_DRAWER_ID;
+    drawer.className = "cart-drawer";
+    drawer.setAttribute("aria-hidden", "true");
+    drawer.innerHTML = `
+      <div class="cart-drawer__overlay" data-cart-dismiss=""></div>
+      <aside class="cart-drawer__panel" role="dialog" aria-modal="true" aria-labelledby="cartDrawerTitle">
+        <header class="cart-drawer__header">
+          <h2 id="cartDrawerTitle">Your cart</h2>
+          <button class="cart-drawer__close" type="button" data-cart-dismiss="" aria-label="Close cart">×</button>
+        </header>
+        <div id="${CART_ITEMS_ID}" class="cart-drawer__body"></div>
+        <footer class="cart-drawer__footer">
+          <div class="cart-drawer__total">
+            <span>Total</span>
+            <strong id="${CART_TOTAL_ID}">0</strong>
+          </div>
+          <a class="btn" id="cartCheckoutButton" href="checkout.html">Go to checkout</a>
+          <button class="btn btn-ghost" type="button" data-cart-clear="">Clear cart</button>
+        </footer>
+      </aside>
+    `;
+    document.body.appendChild(drawer);
+  }
+  drawer.querySelectorAll("[data-cart-dismiss]").forEach((element) => {
+    element.addEventListener("click", closeDrawer);
+  });
+  const clearBtn = drawer.querySelector("[data-cart-clear]");
+  if (clearBtn) {
+    clearBtn.addEventListener("click", () => {
+      setSelectedServices([]);
+      showStatus("Cart cleared");
+    });
+  }
+  const checkoutLink = drawer.querySelector("#cartCheckoutButton");
+  if (checkoutLink) {
+    checkoutLink.addEventListener("click", () => {
+      closeDrawer();
+    });
+  }
+  return drawer;
+}
+
+function openDrawer() {
+  const drawer = byId(CART_DRAWER_ID);
+  const toggle = byId("cartToggle");
+  if (!drawer || !toggle) return;
+  drawer.classList.add("is-open");
+  drawer.setAttribute("aria-hidden", "false");
+  toggle.setAttribute("aria-expanded", "true");
+  const firstFocusable = drawer.querySelector(
+    "button, a, input, textarea, select, [tabindex]:not([tabindex='-1'])"
+  );
+  if (firstFocusable) {
+    setTimeout(() => firstFocusable.focus(), 100);
+  }
+}
+
+function closeDrawer() {
+  const drawer = byId(CART_DRAWER_ID);
+  const toggle = byId("cartToggle");
+  if (!drawer || !toggle) return;
+  drawer.classList.remove("is-open");
+  drawer.setAttribute("aria-hidden", "true");
+  toggle.setAttribute("aria-expanded", "false");
+  toggle.focus();
+}
+
+function updateBadge() {
+  const countEl = byId(CART_COUNT_ID);
+  if (countEl) {
+    countEl.textContent = String(cartIds.size);
+  }
+  const checkoutButton = byId("cartCheckoutButton");
+  if (checkoutButton) {
+    checkoutButton.classList.toggle("is-disabled", !cartIds.size);
+    checkoutButton.setAttribute("aria-disabled", String(!cartIds.size));
+    checkoutButton.setAttribute("tabindex", cartIds.size ? "0" : "-1");
+  }
+}
+
+function renderCartItems() {
+  const container = byId(CART_ITEMS_ID);
+  if (!container) return;
+  const items = Array.from(cartIds)
+    .map((id) => serviceIndex.get(id))
+    .filter(Boolean);
+  container.innerHTML = "";
+  if (!items.length) {
+    container.innerHTML = '<p class="cart-empty muted">Your cart is currently empty.</p>';
+    const total = byId(CART_TOTAL_ID);
+    if (total) total.textContent = "0";
+    return;
+  }
+  const list = document.createElement("ul");
+  list.className = "cart-line-items";
+  let totalAmount = 0;
+  items.forEach((item) => {
+    const li = document.createElement("li");
+    li.className = "cart-line-item";
+    const price = Number.isFinite(Number(item.price)) ? Number(item.price) : null;
+    if (price !== null) {
+      totalAmount += price;
+    }
+    const priceLabel = price !== null
+      ? formatCurrency(price, billingCurrency)
+      : item.priceLabel || "";
+    li.innerHTML = `
+      <div>
+        <strong>${item.title}</strong>
+        <span class="cart-line-item__meta">${item.category || "Consulting"}</span>
+      </div>
+      <div class="cart-line-item__actions">
+        <span class="cart-line-item__price">${priceLabel}</span>
+        <button type="button" class="btn btn-ghost cart-remove" data-cart-remove="${item.id}">Remove</button>
+      </div>
+    `;
+    list.appendChild(li);
+  });
+  container.appendChild(list);
+  container.querySelectorAll("[data-cart-remove]").forEach((button) => {
+    button.addEventListener("click", (event) => {
+      const id = event.currentTarget.getAttribute("data-cart-remove");
+      removeItem(id);
+    });
+  });
+  const total = byId(CART_TOTAL_ID);
+  if (total) {
+    total.textContent = formatCurrency(totalAmount, billingCurrency);
+  }
+}
+
+function syncFromSelected(ids = []) {
+  cartIds = new Set(Array.isArray(ids) ? ids.filter(Boolean) : []);
+  updateBadge();
+  renderCartItems();
+}
+
+function addItem(id) {
+  if (!id) return;
+  const existing = new Set(cartIds);
+  if (existing.has(id)) {
+    const item = serviceIndex.get(id);
+    showStatus(`${item?.title || "Service"} is already in your cart.`);
+    return;
+  }
+  existing.add(id);
+  cartIds = existing;
+  setSelectedServices([...existing]);
+  const item = serviceIndex.get(id);
+  showStatus(`${item?.title || "Service"} added to cart.`);
+}
+
+function removeItem(id) {
+  if (!id) return;
+  const updated = Array.from(cartIds).filter((itemId) => itemId !== id);
+  cartIds = new Set(updated);
+  setSelectedServices(updated);
+  const item = serviceIndex.get(id);
+  showStatus(`${item?.title || "Service"} removed from cart.`);
+}
+
+function handleCartAdd(event) {
+  const id = event.detail?.id || event.detail?.serviceId;
+  if (!id) return;
+  addItem(id);
+}
+
+function handleCartRemove(event) {
+  const id = event.detail?.id || event.detail?.serviceId;
+  if (!id) return;
+  removeItem(id);
+}
+
+export function initCart(data) {
+  serviceIndex = new Map(
+    (data?.serviceCatalog || []).map((service) => [service.id, service])
+  );
+  billingCurrency = data?.billing?.currency || "AUD";
+  ensureCartToggle();
+  buildDrawer();
+  document.addEventListener("cart:add", handleCartAdd);
+  document.addEventListener("cart:remove", handleCartRemove);
+  document.addEventListener(SELECTED_EVENT, (event) => {
+    syncFromSelected(event.detail?.ids || []);
+  });
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
+      closeDrawer();
+    }
+  });
+  window.addEventListener("storage", (event) => {
+    if (event.key === "selectedServices") {
+      syncFromSelected(getSelectedServices());
+    }
+  });
+  syncFromSelected(getSelectedServices());
+}
+
+export function addServiceToCart(id) {
+  addItem(id);
+}
+
+export function clearCart() {
+  cartIds = new Set();
+  setSelectedServices([]);
+}
+*** End of File

--- a/assets/js/core/storage.js
+++ b/assets/js/core/storage.js
@@ -30,6 +30,11 @@ export function setSelectedServices(services = []) {
     new Set((Array.isArray(services) ? services : []).filter(Boolean))
   );
   localStorage.setItem(SELECTED_SERVICES_KEY, JSON.stringify(unique));
+  if (typeof document !== "undefined") {
+    document.dispatchEvent(
+      new CustomEvent("cart:selectedServices", { detail: { ids: unique } })
+    );
+  }
   return unique;
 }
 

--- a/assets/js/env.sample.js
+++ b/assets/js/env.sample.js
@@ -4,4 +4,15 @@ window.ENV = Object.assign(window.ENV || {}, {
   compareDefaultCategory: "starter",
   auditTable: "secure_it_audit_log",
   auditKey: "replace-with-deployment-secret",
+  database: {
+    host: "127.0.0.1",
+    port: 5432,
+    name: "secure_it",
+    user: "secure_app",
+    passwordEnvVar: "SECURE_IT_DB_PASSWORD",
+  },
+  auth: {
+    storageNamespace: "secure_it",
+    sessionTtlHours: 72,
+  },
 });

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -5,6 +5,8 @@ import { initScrollReveal, initHeaderScrollEffect } from "./core/effects.js";
 import { bindContact, initQuoteGenerator } from "./core/forms.js";
 import { initPageLoader } from "./features/loader.js";
 import { initMobileNav } from "./core/navigation.js";
+import { initAuth } from "./core/auth.js";
+import { initCart } from "./core/cart.js";
 
 initThemeToggle();
 initCookieBanner();
@@ -13,6 +15,8 @@ initPageLoader();
 document.addEventListener("DOMContentLoaded", () => {
   if (!window.DATA) return;
   hydrateSite(window.DATA);
+  initAuth();
+  initCart(window.DATA);
   initMobileNav();
   initScrollReveal();
   initHeaderScrollEffect();

--- a/assets/js/renderers/checkout.js
+++ b/assets/js/renderers/checkout.js
@@ -6,14 +6,21 @@ import {
   toggleSelectedService,
 } from "../core/storage.js";
 import { renderOtherServices } from "./shared.js";
+import { requireAuth } from "../core/auth.js";
 
 export function renderCheckoutPage(data) {
+  const customer = requireAuth("checkout.html");
+  if (!customer) return;
   const plan = getSelectedPlan();
   const info = byId("messageInfo");
   if (info) {
     info.textContent = plan
       ? data.pages?.checkout?.message || ""
       : "No plan selected. Please choose a package from pricing.";
+  }
+  const account = byId("checkoutAccount");
+  if (account) {
+    account.textContent = `Logged in as ${customer.email}`;
   }
   const summaryTarget = byId("orderSummary");
   const servicesCatalog = data.serviceCatalog || [];

--- a/assets/js/renderers/detail.js
+++ b/assets/js/renderers/detail.js
@@ -263,13 +263,30 @@ export function renderDetailPage(data) {
       });
       card.appendChild(ul);
     }
+    const actions = document.createElement("div");
+    actions.className = "detail-card__actions";
+    const cartButton = document.createElement("button");
+    cartButton.type = "button";
+    cartButton.className = "btn";
+    cartButton.textContent = "Add to cart";
+    cartButton.setAttribute(
+      "aria-label",
+      `Add ${service.title} to your cart`
+    );
+    cartButton.addEventListener("click", () => {
+      document.dispatchEvent(
+        new CustomEvent("cart:add", { detail: { id: service.id } })
+      );
+    });
+    actions.appendChild(cartButton);
     if (includeLink) {
       const link = document.createElement("a");
       link.className = "detail-link";
       link.href = `detail.html?type=service&id=${service.id}`;
       link.textContent = "Service details";
-      card.appendChild(link);
+      actions.appendChild(link);
     }
+    card.appendChild(actions);
     return card;
   }
 }

--- a/assets/js/renderers/payment.js
+++ b/assets/js/renderers/payment.js
@@ -12,8 +12,11 @@ import {
   storeLastOrder,
 } from "../core/storage.js";
 import { logCustomerEvent } from "../core/audit.js";
+import { requireAuth } from "../core/auth.js";
 
 export function renderPaymentPage(data) {
+  const customer = requireAuth("payment.html");
+  if (!customer) return;
   const servicesCatalog = data?.serviceCatalog || [];
   const billing = data?.billing || {};
   const summaryTarget = byId("paymentSummary");
@@ -25,6 +28,10 @@ export function renderPaymentPage(data) {
     messageInfo.textContent = plan
       ? data.pages?.payment?.message || ""
       : "No plan selected. Return to pricing to choose your package.";
+  }
+  const account = byId("paymentAccount");
+  if (account) {
+    account.textContent = `Logged in as ${customer.email}`;
   }
 
   const selectedServices = () =>

--- a/assets/js/renderers/pricing.js
+++ b/assets/js/renderers/pricing.js
@@ -162,6 +162,7 @@ export function renderPricingPage(data) {
     renderOtherServices(additional, data.serviceCatalog || [], {
       showCtas: true,
       linkLabel: deepDiveLinkLabel,
+      enableCart: true,
     });
   }
 

--- a/assets/js/renderers/shared.js
+++ b/assets/js/renderers/shared.js
@@ -145,6 +145,7 @@ export function renderOtherServices(target, services = [], options = {}) {
     onToggle,
     detailLink = false,
     scrollable = false,
+    enableCart = false,
   } = options;
   if (!target) return;
   const selectedSet = new Set(selectedIds);
@@ -229,6 +230,24 @@ export function renderOtherServices(target, services = [], options = {}) {
       link.href = `detail.html?type=service&id=${service.id}`;
       link.textContent = linkLabel;
       actions.appendChild(link);
+      hasActions = true;
+    }
+
+    if (enableCart) {
+      const cartBtn = document.createElement("button");
+      cartBtn.type = "button";
+      cartBtn.className = "btn btn-ghost service-chip__cart";
+      cartBtn.textContent = "Add to cart";
+      cartBtn.setAttribute(
+        "aria-label",
+        `Add ${service.title} to your cart`
+      );
+      cartBtn.addEventListener("click", () => {
+        document.dispatchEvent(
+          new CustomEvent("cart:add", { detail: { id: service.id } })
+        );
+      });
+      actions.appendChild(cartBtn);
       hasActions = true;
     }
 

--- a/checkout.html
+++ b/checkout.html
@@ -65,6 +65,7 @@
     <main class="container checkout-page">
       <h1>Checkout</h1>
       <p id="messageInfo"></p>
+      <p id="checkoutAccount" class="muted" aria-live="polite"></p>
       <div
         id="orderSummary"
         class="order-summary"

--- a/database/init.sql
+++ b/database/init.sql
@@ -1,0 +1,76 @@
+-- Secure IT Developers initial database schema.
+-- Run this script against a PostgreSQL database before deploying the customer portal.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS customers (
+    id SERIAL PRIMARY KEY,
+    full_name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    salt TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS products (
+    id SERIAL PRIMARY KEY,
+    slug VARCHAR(120) NOT NULL UNIQUE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    price NUMERIC(12, 2) NOT NULL,
+    currency CHAR(3) NOT NULL DEFAULT 'AUD',
+    category VARCHAR(120)
+);
+
+CREATE TABLE IF NOT EXISTS carts (
+    id SERIAL PRIMARY KEY,
+    customer_id INTEGER NOT NULL REFERENCES customers(id) ON DELETE CASCADE,
+    status VARCHAR(30) NOT NULL DEFAULT 'active',
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS cart_items (
+    id SERIAL PRIMARY KEY,
+    cart_id INTEGER NOT NULL REFERENCES carts(id) ON DELETE CASCADE,
+    product_id INTEGER NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+    quantity INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (cart_id, product_id)
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+    id SERIAL PRIMARY KEY,
+    cart_id INTEGER NOT NULL REFERENCES carts(id) ON DELETE CASCADE,
+    total NUMERIC(12, 2) NOT NULL,
+    currency CHAR(3) NOT NULL DEFAULT 'AUD',
+    reference VARCHAR(32) NOT NULL UNIQUE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS order_items (
+    id SERIAL PRIMARY KEY,
+    order_id INTEGER NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+    product_id INTEGER NOT NULL REFERENCES products(id),
+    quantity INTEGER NOT NULL DEFAULT 1,
+    price_each NUMERIC(12, 2) NOT NULL,
+    currency CHAR(3) NOT NULL DEFAULT 'AUD'
+);
+
+CREATE INDEX IF NOT EXISTS idx_products_slug ON products(slug);
+CREATE INDEX IF NOT EXISTS idx_carts_customer ON carts(customer_id);
+CREATE INDEX IF NOT EXISTS idx_cart_items_cart ON cart_items(cart_id);
+CREATE INDEX IF NOT EXISTS idx_orders_cart ON orders(cart_id);
+CREATE INDEX IF NOT EXISTS idx_order_items_order ON order_items(order_id);
+
+INSERT INTO products (slug, name, description, price, category)
+VALUES
+    ('security-audit', 'Security & compliance audit', 'Deep-dive review mapped to OWASP and ISO controls.', 3600.00, 'Security'),
+    ('seo-technical', 'Technical SEO & content sprint', 'Optimise Core Web Vitals, schema, and editorial workflows.', 2950.00, 'Growth'),
+    ('performance-hardening', 'Performance hardening', 'Stress-test and tune critical journeys with profiling and caching.', 2400.00, 'Engineering'),
+    ('api-integration', 'API & integration build', 'Design and ship robust REST or GraphQL endpoints.', 4200.00, 'Engineering'),
+    ('mobile-polish', 'Mobile polish sprint', 'Stabilise Flutter or React Native apps with performance tuning.', 3300.00, 'Mobile'),
+    ('ux-accessibility', 'Accessibility & UX review', 'Audit flows against WCAG 2.2 AA with actionable remediation.', 1750.00, 'Experience')
+ON CONFLICT (slug) DO NOTHING;
+
+COMMIT;

--- a/login.html
+++ b/login.html
@@ -3,19 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Secure IT Developers</title>
-    <meta name="description" content="" />
-    <meta name="keywords" content="" />
-    <link rel="canonical" href="#" />
-    <meta property="og:title" content="" />
-    <meta property="og:description" content="" />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="" />
-    <meta property="og:image" content="" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="" />
-    <meta name="twitter:description" content="" />
-    <meta name="twitter:image" content="" />
+    <title>Secure IT Developers — Customer login</title>
+    <meta name="description" content="Secure IT Developers customer login." />
     <link rel="icon" href="assets/img/favicon.svg" />
     <link rel="stylesheet" href="assets/css/styles.css" />
     <script defer src="assets/js/env.js"></script>
@@ -24,7 +13,7 @@
     <script id="orgJsonLd" type="application/ld+json"></script>
   </head>
 
-  <body data-page="payment">
+  <body data-page="login">
     <div id="pageLoader" class="page-loader" aria-hidden="true">
       <div class="page-loader__spinner"></div>
       <p>Loading Secure IT Developers…</p>
@@ -58,85 +47,47 @@
         >
           🌓
         </button>
-
       </div>
     </header>
 
-    <main class="container payment-page">
-      <h1>Payment</h1>
-      <p id="messageInfo" class="muted"></p>
-      <p id="paymentAccount" class="muted" aria-live="polite"></p>
-      <ol class="progress" aria-label="Checkout steps">
-        <li class="done">Order</li>
-        <li class="done">Billing</li>
-        <li class="current">Payment</li>
-      </ol>
-      <section class="cart-review js-reveal" aria-labelledby="cartHeading">
-        <h2 id="cartHeading">Review your secure order</h2>
-        <div id="paymentSummary" class="cart-summary"></div>
+    <main class="container auth-page" role="main">
+      <section class="auth-card" aria-labelledby="loginHeading">
+        <h1 id="loginHeading">Customer login</h1>
+        <p>
+          Sign in with your Secure IT Developers account to review your cart and
+          continue checkout. Database credentials are loaded from your environment
+          file, keeping production secrets off the client.
+        </p>
+        <div id="dbConfigNotice" class="auth-db" aria-live="polite"></div>
+        <form id="loginForm" class="form auth-form" novalidate>
+          <div class="form-row">
+            <label for="loginEmail">Email</label>
+            <input
+              id="loginEmail"
+              name="email"
+              type="email"
+              autocomplete="email"
+              required
+            />
+          </div>
+          <div class="form-row">
+            <label for="loginPassword">Password</label>
+            <input
+              id="loginPassword"
+              name="password"
+              type="password"
+              minlength="8"
+              autocomplete="current-password"
+              required
+            />
+          </div>
+          <button class="btn" type="submit">Log in</button>
+          <p id="loginStatus" class="form-status" role="status" aria-live="polite"></p>
+        </form>
+        <p class="auth-switch">
+          Need an account? <a href="signup.html">Create one in minutes.</a>
+        </p>
       </section>
-      <form id="paymentForm" class="form" novalidate>
-        <fieldset>
-          <legend>Billing details</legend>
-          <div class="grid-2">
-            <div class="form-row">
-              <label for="fullname">Full name</label>
-              <input id="fullname" required />
-            </div>
-            <div class="form-row">
-              <label for="emailPay">Email</label>
-              <input id="emailPay" type="email" required />
-            </div>
-          </div>
-          <div class="form-row">
-            <label for="address">Address</label>
-            <input id="address" required />
-          </div>
-          <div class="grid-3">
-            <div class="form-row">
-              <label for="city">City</label>
-              <input id="city" required />
-            </div>
-            <div class="form-row">
-              <label for="state">State</label>
-              <input id="state" required />
-            </div>
-            <div class="form-row">
-              <label for="zip">Postcode</label>
-              <input id="zip" required />
-            </div>
-          </div>
-        </fieldset>
-        <fieldset>
-          <legend>Card</legend>
-          <div class="grid-2">
-            <div class="form-row">
-              <label for="card">Card number</label>
-              <input
-                id="card"
-                inputmode="numeric"
-                pattern="[0-9 ]{12,19}"
-                required
-                placeholder="4242 4242 4242 4242"
-              />
-            </div>
-            <div class="form-row">
-              <label for="exp">Expiry</label>
-              <input id="exp" placeholder="MM/YY" required />
-            </div>
-          </div>
-          <div class="form-row">
-            <label for="cvc">CVC</label>
-            <input id="cvc" inputmode="numeric" pattern="[0-9]{3,4}" required />
-          </div>
-        </fieldset>
-        <div class="order-inline" id="miniSummary"></div>
-        <div class="actions">
-          <button type="submit" class="btn">Pay now</button>
-          <a class="btn btn-ghost" href="checkout.html">Back</a>
-        </div>
-        <p id="payStatus" role="status" aria-live="polite"></p>
-      </form>
     </main>
 
     <footer class="site-footer">

--- a/signup.html
+++ b/signup.html
@@ -3,19 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Secure IT Developers</title>
-    <meta name="description" content="" />
-    <meta name="keywords" content="" />
-    <link rel="canonical" href="#" />
-    <meta property="og:title" content="" />
-    <meta property="og:description" content="" />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="" />
-    <meta property="og:image" content="" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="" />
-    <meta name="twitter:description" content="" />
-    <meta name="twitter:image" content="" />
+    <title>Secure IT Developers — Create an account</title>
+    <meta name="description" content="Create a Secure IT Developers customer account." />
     <link rel="icon" href="assets/img/favicon.svg" />
     <link rel="stylesheet" href="assets/css/styles.css" />
     <script defer src="assets/js/env.js"></script>
@@ -24,7 +13,7 @@
     <script id="orgJsonLd" type="application/ld+json"></script>
   </head>
 
-  <body data-page="payment">
+  <body data-page="signup">
     <div id="pageLoader" class="page-loader" aria-hidden="true">
       <div class="page-loader__spinner"></div>
       <p>Loading Secure IT Developers…</p>
@@ -58,85 +47,66 @@
         >
           🌓
         </button>
-
       </div>
     </header>
 
-    <main class="container payment-page">
-      <h1>Payment</h1>
-      <p id="messageInfo" class="muted"></p>
-      <p id="paymentAccount" class="muted" aria-live="polite"></p>
-      <ol class="progress" aria-label="Checkout steps">
-        <li class="done">Order</li>
-        <li class="done">Billing</li>
-        <li class="current">Payment</li>
-      </ol>
-      <section class="cart-review js-reveal" aria-labelledby="cartHeading">
-        <h2 id="cartHeading">Review your secure order</h2>
-        <div id="paymentSummary" class="cart-summary"></div>
+    <main class="container auth-page" role="main">
+      <section class="auth-card" aria-labelledby="signupHeading">
+        <h1 id="signupHeading">Create your account</h1>
+        <p>
+          Set up a secure customer login so you can build a cart, manage orders,
+          and confirm projects with confidence. Passwords are hashed locally before
+          being stored.
+        </p>
+        <form id="signupForm" class="form auth-form" novalidate>
+          <div class="form-row">
+            <label for="signupName">Full name</label>
+            <input
+              id="signupName"
+              name="fullname"
+              autocomplete="name"
+              required
+            />
+          </div>
+          <div class="form-row">
+            <label for="signupEmail">Email</label>
+            <input
+              id="signupEmail"
+              name="email"
+              type="email"
+              autocomplete="email"
+              required
+            />
+          </div>
+          <div class="form-row">
+            <label for="signupPassword">Password</label>
+            <input
+              id="signupPassword"
+              name="password"
+              type="password"
+              minlength="8"
+              autocomplete="new-password"
+              required
+            />
+          </div>
+          <div class="form-row">
+            <label for="signupConfirm">Confirm password</label>
+            <input
+              id="signupConfirm"
+              name="confirm"
+              type="password"
+              minlength="8"
+              autocomplete="new-password"
+              required
+            />
+          </div>
+          <button class="btn" type="submit">Create account</button>
+          <p id="signupStatus" class="form-status" role="status" aria-live="polite"></p>
+        </form>
+        <p class="auth-switch">
+          Already registered? <a href="login.html">Log in to continue.</a>
+        </p>
       </section>
-      <form id="paymentForm" class="form" novalidate>
-        <fieldset>
-          <legend>Billing details</legend>
-          <div class="grid-2">
-            <div class="form-row">
-              <label for="fullname">Full name</label>
-              <input id="fullname" required />
-            </div>
-            <div class="form-row">
-              <label for="emailPay">Email</label>
-              <input id="emailPay" type="email" required />
-            </div>
-          </div>
-          <div class="form-row">
-            <label for="address">Address</label>
-            <input id="address" required />
-          </div>
-          <div class="grid-3">
-            <div class="form-row">
-              <label for="city">City</label>
-              <input id="city" required />
-            </div>
-            <div class="form-row">
-              <label for="state">State</label>
-              <input id="state" required />
-            </div>
-            <div class="form-row">
-              <label for="zip">Postcode</label>
-              <input id="zip" required />
-            </div>
-          </div>
-        </fieldset>
-        <fieldset>
-          <legend>Card</legend>
-          <div class="grid-2">
-            <div class="form-row">
-              <label for="card">Card number</label>
-              <input
-                id="card"
-                inputmode="numeric"
-                pattern="[0-9 ]{12,19}"
-                required
-                placeholder="4242 4242 4242 4242"
-              />
-            </div>
-            <div class="form-row">
-              <label for="exp">Expiry</label>
-              <input id="exp" placeholder="MM/YY" required />
-            </div>
-          </div>
-          <div class="form-row">
-            <label for="cvc">CVC</label>
-            <input id="cvc" inputmode="numeric" pattern="[0-9]{3,4}" required />
-          </div>
-        </fieldset>
-        <div class="order-inline" id="miniSummary"></div>
-        <div class="actions">
-          <button type="submit" class="btn">Pay now</button>
-          <a class="btn btn-ghost" href="checkout.html">Back</a>
-        </div>
-        <p id="payStatus" role="status" aria-live="polite"></p>
-      </form>
     </main>
 
     <footer class="site-footer">


### PR DESCRIPTION
## Summary
- implement a lightweight client-side auth module with login/signup pages, navigation controls, and database configuration messaging driven from env variables
- add a persistent cart drawer so services can be added while browsing and synced with checkout selections
- require customers to authenticate before checkout and payment while surfacing account context during those flows, plus seed the database schema for customers, carts, and products

## Testing
- not run (static site with no automated test suite)


------
https://chatgpt.com/codex/tasks/task_e_68d4bee66cc8833383b97e7c5435ae49