### PR TITLE
Fix page loader hang by removing invalid EOF markers

### DIFF
--- a/assets/js/core/auth.js
+++ b/assets/js/core/auth.js
@@ -433,5 +433,3 @@ export function initAuth() {
   document.addEventListener(AUTH_CHANGE_EVENT, renderAuthControls);
   document.addEventListener(AUTH_CHANGE_EVENT, renderDatabaseNotice);
 }
-
-*** End of File

--- a/assets/js/core/cart.js
+++ b/assets/js/core/cart.js
@@ -278,4 +278,3 @@ export function clearCart() {
   cartIds = new Set();
   setSelectedServices([]);
 }
-*** End of File


### PR DESCRIPTION
## Summary
- remove stray `*** End of File` markers from the auth and cart modules so the JavaScript bundle parses correctly
- allow the page loader to hide once the window load event fires, restoring access to the site content

## Testing
- node --check assets/js/core/auth.js
- node --check assets/js/core/cart.js

------
https://chatgpt.com/codex/tasks/task_e_68d4c69bd7c0833384016bc82d8954c8