### PR TITLE
Add secure payment gateway and Google auth enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Environment configuration (keep secrets out of version control)
+assets/js/env.local.js
+.env
+.env.*
+
+# Build artefacts
+node_modules/
+dist/
+
+# OS / editor noise
+.DS_Store
+Thumbs.db

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -783,17 +783,18 @@ textarea::placeholder {
 }
 
 .service-chip-list {
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(260px, 1fr);
+  display: flex;
+  flex-wrap: nowrap;
   gap: 16px;
   overflow-x: auto;
   padding: 0 4px 12px;
   scroll-snap-type: x proximity;
   scrollbar-width: thin;
+  align-items: stretch;
 }
 
 .service-chip-list .service-chip {
+  flex: 0 0 min(320px, 80vw);
   min-width: 260px;
   scroll-snap-align: start;
 }
@@ -1801,24 +1802,79 @@ textarea::placeholder {
 }
 
 .auth-db {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.callout {
+  border-radius: 12px;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--card) 85%, transparent);
+  color: var(--text);
+}
+
+.callout--info {
+  border-color: color-mix(in srgb, var(--brand) 40%, var(--border));
+  background: color-mix(in srgb, var(--brand) 12%, var(--card));
+}
+
+.callout--warning {
+  border-color: color-mix(in srgb, #f97316 55%, var(--border));
+  background: color-mix(in srgb, #f97316 12%, var(--card));
+}
+
+.callout--error {
+  border-color: color-mix(in srgb, #ef4444 65%, var(--border));
+  background: color-mix(in srgb, #ef4444 10%, var(--card));
+}
+
+.auth-provider {
+  display: grid;
+  gap: 12px;
+}
+
+.oauth-button-slot {
+  display: flex;
+  justify-content: center;
+}
+
+.oauth-status {
   font-size: 0.85rem;
   color: var(--muted);
-  background: color-mix(in srgb, var(--card) 75%, transparent);
-  border: 1px dashed var(--border);
-  border-radius: 12px;
-  padding: 12px 16px;
+  min-height: 20px;
 }
 
-.auth-db__list {
-  list-style: none;
+.oauth-divider {
+  position: relative;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--muted);
   margin: 8px 0 0;
-  padding: 0;
-  display: grid;
-  gap: 4px;
 }
 
-.auth-db__list strong {
-  color: var(--text);
+.oauth-divider::before,
+.oauth-divider::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  width: 40%;
+  height: 1px;
+  background: var(--border);
+}
+
+.oauth-divider::before {
+  left: 0;
+}
+
+.oauth-divider::after {
+  right: 0;
+}
+
+.oauth-divider span {
+  display: inline-block;
+  padding: 0 8px;
+  background: var(--bg);
 }
 
 @media (max-width: 640px) {

--- a/assets/js/core/gateway.js
+++ b/assets/js/core/gateway.js
@@ -1,0 +1,153 @@
+const DEFAULT_TIMEOUT = 15000;
+const PLACEHOLDER_PATTERN = /replace/i;
+
+function isPlaceholder(value) {
+  return !value || PLACEHOLDER_PATTERN.test(String(value));
+}
+
+function withTimeout(factory, timeout) {
+  const controller = new AbortController();
+  const operation = factory(controller.signal);
+  if (!timeout) {
+    return operation;
+  }
+  const timer = setTimeout(() => controller.abort(), timeout);
+  const finalize = () => clearTimeout(timer);
+  if (typeof operation.finally === "function") {
+    return operation.finally(finalize);
+  }
+  return (async () => {
+    try {
+      return await operation;
+    } finally {
+      finalize();
+    }
+  })();
+}
+
+export class PaymentGateway {
+  constructor(config = {}) {
+    this.mode = config.mode || "test";
+    this.provider = config.provider || "Gateway";
+    this.endpoint = config.endpoint || "";
+    this.publishableKey = config.publishableKey || "";
+    this.timeout = Number(config.timeoutMs) || DEFAULT_TIMEOUT;
+  }
+
+  static fromEnv(config = {}) {
+    return new PaymentGateway(config || {});
+  }
+
+  get isLive() {
+    return String(this.mode).toLowerCase() === "live";
+  }
+
+  get isConfigured() {
+    if (isPlaceholder(this.publishableKey)) {
+      return false;
+    }
+    if (this.isLive() && !this.endpoint) {
+      return false;
+    }
+    return true;
+  }
+
+  ensureConfigured() {
+    if (!this.isConfigured) {
+      throw new Error(
+        "Payment gateway is not configured. Update paymentGateway settings in assets/js/env.local.js."
+      );
+    }
+  }
+
+  buildPayload({ order, card, billing }) {
+    return {
+      amount: order.amount,
+      currency: order.currency,
+      reference: order.reference,
+      planId: order.plan?.id || null,
+      services: (order.services || []).map((service) => ({
+        id: service.id,
+        title: service.title,
+        price: service.price || null,
+        priceLabel: service.priceLabel || null,
+      })),
+      customer: {
+        name: order.name,
+        email: order.email,
+      },
+      billing: {
+        address: billing?.address || null,
+      },
+      card: {
+        number: card.number,
+        expMonth: card.expMonth,
+        expYear: card.expYear,
+        cvc: card.cvc,
+      },
+      metadata: {
+        provider: this.provider,
+        mode: this.mode,
+      },
+    };
+  }
+
+  async request(payload) {
+    if (!this.endpoint || (!this.isLive() && !this.endpoint)) {
+      return {
+        ok: true,
+        transactionId: `test_${Date.now()}`,
+        mode: this.mode,
+      };
+    }
+    return withTimeout(
+      async (signal) => {
+        const response = await fetch(this.endpoint, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${this.publishableKey}`,
+          },
+          body: JSON.stringify(payload),
+          signal,
+        });
+        if (!response.ok) {
+          const message = await response.text();
+          throw new Error(message || "Payment request failed");
+        }
+        const data = await response.json().catch(() => ({}));
+        if (data && data.error) {
+          throw new Error(data.error);
+        }
+        return data || { ok: true };
+      },
+      this.timeout
+    );
+  }
+
+  async processPayment({ order, card, billing }) {
+    this.ensureConfigured();
+    if (!order?.reference) {
+      throw new Error("Missing order reference. Refresh and try again.");
+    }
+    if (!card?.number || !card?.expMonth || !card?.expYear) {
+      throw new Error("Card details are incomplete. Check the number and expiry.");
+    }
+    const payload = this.buildPayload({ order, card, billing });
+    try {
+      const result = await this.request(payload);
+      return {
+        ok: result?.ok !== false,
+        transactionId:
+          result?.transactionId || result?.id || `txn_${Date.now().toString(36)}`,
+        receiptUrl: result?.receiptUrl || null,
+        mode: result?.mode || this.mode,
+      };
+    } catch (error) {
+      if (error.name === "AbortError") {
+        throw new Error("Payment timed out. Please try again.");
+      }
+      throw new Error(error?.message || "Unable to process payment.");
+    }
+  }
+}

--- a/assets/js/core/storage.js
+++ b/assets/js/core/storage.js
@@ -70,6 +70,8 @@ export function storeLastOrder(order) {
   const payload = {
     ...order,
     services,
+    billingAddress: order.billingAddress || null,
+    cardLast4: order.cardLast4 || null,
   };
   localStorage.setItem("lastOrder", JSON.stringify(payload));
 }

--- a/assets/js/core/utils.js
+++ b/assets/js/core/utils.js
@@ -105,7 +105,13 @@ export function parseExpiry(value = "") {
   const fullYear = 2000 + year;
   const now = new Date();
   const expiryDate = new Date(fullYear, month);
-  return { valid: expiryDate > now };
+  return {
+    valid: expiryDate > now,
+    month,
+    year: fullYear,
+    shortYear: yy,
+    formatted: `${String(month).padStart(2, "0")}/${yy}`,
+  };
 }
 
 export function generateReference() {

--- a/assets/js/env.js
+++ b/assets/js/env.js
@@ -1,1 +1,8 @@
-window.ENV = window.ENV || {};
+(function applyEnvironment() {
+  const base = window.ENV && typeof window.ENV === "object" ? window.ENV : {};
+  const local =
+    window.SECURE_ENV && typeof window.SECURE_ENV === "object"
+      ? window.SECURE_ENV
+      : {};
+  window.ENV = Object.assign({}, base, local);
+})();

--- a/assets/js/env.sample.js
+++ b/assets/js/env.sample.js
@@ -1,3 +1,4 @@
+// Copy this file to assets/js/env.local.js and update the values privately.
 window.ENV = Object.assign(window.ENV || {}, {
   contactEndpoint: "https://formsubmit.co/ajax/rans.rath@gmail.com",
   quoteEndpoint: "https://formsubmit.co/ajax/rans.rath@gmail.com",
@@ -14,5 +15,16 @@ window.ENV = Object.assign(window.ENV || {}, {
   auth: {
     storageNamespace: "secure_it",
     sessionTtlHours: 72,
+  },
+  paymentGateway: {
+    mode: "test",
+    provider: "Stripe",
+    publishableKey: "pk_test_replace_with_publishable_key",
+    endpoint: "",
+    timeoutMs: 15000,
+  },
+  googleAuth: {
+    clientId: "replace-with-your-google-client-id.apps.googleusercontent.com",
+    autoSelect: false,
   },
 });

--- a/assets/js/renderers/message.js
+++ b/assets/js/renderers/message.js
@@ -28,6 +28,24 @@ export function renderMessagePage(pageKey, data) {
     if (order?.plan) {
       const services = Array.isArray(order.services) ? order.services : [];
       const breakdown = order.breakdown || {};
+      const paymentMeta = [
+        order.transactionId
+          ? `<li><strong>Payment ID:</strong> ${order.transactionId}</li>`
+          : "",
+        order.cardLast4
+          ? `<li><strong>Card:</strong> **** **** **** ${order.cardLast4}</li>`
+          : "",
+        order.gatewayProvider
+          ? `<li><strong>Processor:</strong> ${order.gatewayProvider}${
+              order.gatewayMode ? ` (${String(order.gatewayMode).toUpperCase()} mode)` : ""
+            }</li>`
+          : "",
+        order.receiptUrl
+          ? `<li><strong>Receipt:</strong> <a href="${order.receiptUrl}" target="_blank" rel="noopener">Download receipt</a></li>`
+          : "",
+      ]
+        .filter(Boolean)
+        .join("");
       const servicesMarkup = services.length
         ? `<li><strong>Add-ons:</strong>
             <ul class="order-services">${services
@@ -69,6 +87,7 @@ export function renderMessagePage(pageKey, data) {
           <li><strong>Amount:</strong> ${formatCurrency(order.amount, order.currency)}</li>
           <li><strong>Client:</strong> ${order.name || "Pending"}</li>
           <li><strong>Email:</strong> ${order.email || "Pending"}</li>
+          ${paymentMeta}
           ${servicesMarkup}
           ${breakdownMarkup}
         </ul>

--- a/login.html
+++ b/login.html
@@ -55,10 +55,25 @@
         <h1 id="loginHeading">Customer login</h1>
         <p>
           Sign in with your Secure IT Developers account to review your cart and
-          continue checkout. Database credentials are loaded from your environment
-          file, keeping production secrets off the client.
+          continue checkout. Database connections stay on the server so secrets
+          never appear in the browser.
         </p>
-        <div id="dbConfigNotice" class="auth-db" aria-live="polite"></div>
+        <div
+          id="dbConfigNotice"
+          class="auth-db"
+          aria-live="polite"
+          role="status"
+        ></div>
+        <div class="auth-provider" aria-label="Social sign-in options">
+          <div id="googleLogin" class="oauth-button-slot"></div>
+          <p
+            id="googleLoginStatus"
+            class="oauth-status"
+            role="status"
+            aria-live="polite"
+          ></p>
+          <div class="oauth-divider"><span>or continue with email</span></div>
+        </div>
         <form id="loginForm" class="form auth-form" novalidate>
           <div class="form-row">
             <label for="loginEmail">Email</label>

--- a/payment.html
+++ b/payment.html
@@ -66,6 +66,12 @@
       <h1>Payment</h1>
       <p id="messageInfo" class="muted"></p>
       <p id="paymentAccount" class="muted" aria-live="polite"></p>
+      <div
+        id="gatewayStatus"
+        class="callout"
+        role="status"
+        aria-live="polite"
+      ></div>
       <ol class="progress" aria-label="Checkout steps">
         <li class="done">Order</li>
         <li class="done">Billing</li>

--- a/signup.html
+++ b/signup.html
@@ -58,6 +58,16 @@
           and confirm projects with confidence. Passwords are hashed locally before
           being stored.
         </p>
+        <div class="auth-provider" aria-label="Social sign-up options">
+          <div id="googleSignup" class="oauth-button-slot"></div>
+          <p
+            id="googleSignupStatus"
+            class="oauth-status"
+            role="status"
+            aria-live="polite"
+          ></p>
+          <div class="oauth-divider"><span>or create an email login</span></div>
+        </div>
         <form id="signupForm" class="form auth-form" novalidate>
           <div class="form-row">
             <label for="signupName">Full name</label>


### PR DESCRIPTION
## Summary
- fix the checkout recommended services rail so cards align horizontally with standard spacing
- hide raw database credentials in the auth views and surface environment configuration warnings via callouts
- add a configurable payment gateway client with UI messaging, transaction persistence and improved success receipt details
- integrate Google sign-in/sign-up buttons with robust error handling and clear setup guidance for missing client IDs
- introduce `.gitignore` and environment bootstrap changes so secrets live outside version control

## Testing
- no automated tests were run (static site project)


------
https://chatgpt.com/codex/tasks/task_e_68d4cd2873348333bcaa661fe27a23ed