### PR TITLE
Limit contact selectors to two visible items with horizontal scroll

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -864,12 +864,25 @@ textarea::placeholder {
 .service-selector__grid {
   display: grid;
   gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(2, minmax(220px, 1fr));
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(220px, 1fr);
+  overflow-x: auto;
   padding: 0;
+  margin: 0;
+  scroll-snap-type: x proximity;
+  -webkit-overflow-scrolling: touch;
+}
+
+@media (max-width: 720px) {
+  .service-selector__grid {
+    grid-template-columns: repeat(1, minmax(220px, 1fr));
+  }
 }
 
 .service-selector__grid .service-option {
   height: 100%;
+  scroll-snap-align: start;
 }
 
 .contact-page .service-selector {


### PR DESCRIPTION
## Summary
- constrain the contact form package and service selectors to two visible cards
- enable horizontal scrolling with snap alignment for additional options
- add a responsive fallback for narrow viewports

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5d412a3488333a2be1491be4ff885