### PR TITLE
Limit contact form selections to scrollable panels

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -895,6 +895,17 @@ textarea::placeholder {
   padding: clamp(16px, 3vw, 20px);
 }
 
+.contact-page .service-selector__grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-auto-flow: row;
+  grid-auto-columns: unset;
+  overflow-x: hidden;
+  overflow-y: auto;
+  max-height: clamp(220px, 40vh, 320px);
+  padding-right: 8px;
+  scrollbar-gutter: stable both-edges;
+}
+
 .contact-page {
   display: flex;
   flex-direction: column;

--- a/contact.html
+++ b/contact.html
@@ -146,7 +146,6 @@
                   name="message"
                   rows="5"
                   placeholder="Outline goals, milestones, or blockers."
-                  required
                 ></textarea>
               </div>
               <input type="hidden" name="form" value="Contact page" />


### PR DESCRIPTION
## Summary
- limit contact page service pickers to vertically scrollable panels so the rest of the form stays fixed
- allow the project background field to be optional by removing the required attribute

## Testing
- no automated tests were run (static HTML/CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68d5d516469883338dd4eaa041bc50b4