### PR TITLE
Improve footer column layout

### DIFF
--- a/assets/css/components/pricing.css
+++ b/assets/css/components/pricing.css
@@ -223,8 +223,13 @@
 }
 .foot-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 16px;
+  gap: 24px;
+}
+
+.foot-grid > div {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 .footer-contact,
 .footer-security {
@@ -326,6 +331,29 @@
 }
 .foot-links__list a {
   color: var(--muted);
+}
+
+@media (min-width: 640px) {
+  .foot-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .foot-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 639px) {
+  .foot-bottom {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .foot-links {
+    margin-left: 0;
+  }
 }
 .cookie-banner {
   position: fixed;


### PR DESCRIPTION
## Summary
- adjust the footer grid styling to better align column content and spacing
- add responsive breakpoints so the footer displays as two columns on tablets and four columns on desktops
- ensure the footer bottom section stacks neatly on narrow screens

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5e2d19f0c83339c6ff1ed5f9255c8