### PR TITLE
Adjust footer grid spacing and alignment

### DIFF
--- a/assets/css/components/pricing.css
+++ b/assets/css/components/pricing.css
@@ -224,6 +224,8 @@
 .foot-grid {
   display: grid;
   gap: 24px;
+  align-items: start;
+  justify-items: start;
 }
 
 .foot-grid > div {
@@ -335,13 +337,15 @@
 
 @media (min-width: 640px) {
   .foot-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    column-gap: 32px;
+    row-gap: 32px;
   }
 }
 
 @media (min-width: 1024px) {
   .foot-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(220px, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- align footer grid columns by anchoring their content to the start
- expand responsive column definitions to keep consistent spacing across breakpoints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5e40fb9e88333b4d5b2a723b2c29b