### PR TITLE
Improve pricing comparison layout

### DIFF
--- a/assets/css/components/pricing.css
+++ b/assets/css/components/pricing.css
@@ -186,12 +186,16 @@
   color: var(--muted);
 }
 .compare-grid {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 12px;
+  overflow-x: auto;
+  width: 100%;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 4px;
 }
 .compare-row {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 12px;
   align-items: start;
   padding: 12px;

--- a/assets/js/renderers/pricing.js
+++ b/assets/js/renderers/pricing.js
@@ -290,8 +290,13 @@ export function renderCompareTable(data) {
     table.appendChild(summary);
     const grid = document.createElement("div");
     grid.className = "compare-grid";
+    const columnCount = (category.columns || []).length;
+    const columnTemplate = `minmax(200px, 1.1fr) repeat(${columnCount}, minmax(180px, 1fr))`;
+    const minWidth = `${200 + 180 * columnCount}px`;
     const header = document.createElement("div");
     header.className = "compare-row compare-row--header";
+    header.style.gridTemplateColumns = columnTemplate;
+    header.style.minWidth = minWidth;
     header.innerHTML =
       '<span class="compare-label">Criteria</span>' +
       (category.columns || [])
@@ -305,6 +310,8 @@ export function renderCompareTable(data) {
     (category.rows || []).forEach((row) => {
       const div = document.createElement("div");
       div.className = "compare-row";
+      div.style.gridTemplateColumns = columnTemplate;
+      div.style.minWidth = minWidth;
       const label = document.createElement("span");
       label.className = "compare-label";
       label.textContent = row.label;


### PR DESCRIPTION
## Summary
- ensure the pricing comparison grid renders each category with consistent column layouts
- add minimum widths and horizontal scrolling so plan differences stay visible side-by-side

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5e56076888333a1584b4165d18269