### PR TITLE
Fix Google sign-in initialization when env overrides load late

### DIFF
--- a/assets/js/env.js
+++ b/assets/js/env.js
@@ -12,6 +12,7 @@
 
   function emitReady(detail) {
     mergeEnvironment();
+    window.__SECURE_ENV_READY__ = { ready: true, detail: detail || null };
     if (typeof document?.dispatchEvent === "function") {
       const EventCtor = typeof window.CustomEvent === "function"
         ? window.CustomEvent


### PR DESCRIPTION
## Summary
- persist the secure environment ready detail globally so late subscribers can detect configuration status
- defer Google sign-in setup until configuration is available and provide clearer loading/unavailable messaging
- normalise the googleAuth client ID field to accept client_id overrides

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d881bc2d6083339de739d5fe73eef2