### PR TITLE
Fix pricing custom engagement visibility and polish contact section

### DIFF
--- a/assets/css/components/home.css
+++ b/assets/css/components/home.css
@@ -308,3 +308,30 @@
   font-style: normal;
   color: var(--muted);
 }
+
+.contact ul {
+  list-style: none;
+  padding: 0;
+  margin: 16px 0 24px;
+  display: grid;
+  gap: 12px;
+}
+
+.contact ul li {
+  position: relative;
+  padding-left: 28px;
+  color: color-mix(in srgb, var(--text) 82%, var(--muted) 18%);
+  line-height: 1.6;
+}
+
+.contact ul li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.55em;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #60a5fa, #2563eb);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--brand) 18%, transparent);
+}

--- a/assets/js/core/effects.js
+++ b/assets/js/core/effects.js
@@ -1,22 +1,43 @@
 export function initScrollReveal() {
-  const revealables = document.querySelectorAll(".js-reveal");
+  const revealables = Array.from(document.querySelectorAll(".js-reveal"));
   if (!revealables.length) return;
+
+  const show = (el) => {
+    if (!el.classList.contains("is-visible")) {
+      el.classList.add("is-visible");
+    }
+  };
+
   if (!("IntersectionObserver" in window)) {
-    revealables.forEach((el) => el.classList.add("is-visible"));
+    revealables.forEach(show);
     return;
   }
+
   const observer = new IntersectionObserver(
     (entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
-          entry.target.classList.add("is-visible");
+          show(entry.target);
           observer.unobserve(entry.target);
         }
       });
     },
     { threshold: 0.2, rootMargin: "0px 0px -10% 0px" }
   );
+
   revealables.forEach((el) => observer.observe(el));
+
+  // Ensure sections already in view after hydration are revealed immediately.
+  requestAnimationFrame(() => {
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+    revealables.forEach((el) => {
+      const rect = el.getBoundingClientRect();
+      if (rect.top < viewportHeight * 0.92 && rect.bottom > 0) {
+        show(el);
+        observer.unobserve(el);
+      }
+    });
+  });
 }
 
 export function initHeaderScrollEffect() {

--- a/assets/js/renderers/pricing.js
+++ b/assets/js/renderers/pricing.js
@@ -233,7 +233,11 @@ export function renderPricingPage(data) {
       const hasContent = aside.innerHTML.trim().length > 0;
       aside.toggleAttribute("hidden", !hasContent);
     }
-    customSection.hidden = !custom.heading && !custom.copy;
+    const shouldHide = !custom.heading && !custom.copy;
+    customSection.hidden = shouldHide;
+    if (!shouldHide) {
+      customSection.classList.add("is-visible");
+    }
   }
 
   const standalone = page.standalone || {};


### PR DESCRIPTION
## Summary
- keep scroll reveal sections visible when they initially render and improve graceful fallback
- ensure the custom engagement block on pricing is visible immediately once populated
- polish the home page contact checklist styling for clarity

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8aac1e2dc83339b62bc581b9cea1b