### PR TITLE
Fix truncated CSS definitions breaking page layouts

### DIFF
--- a/assets/css/components/contact.css
+++ b/assets/css/components/contact.css
@@ -1,5 +1,3 @@
-}
-
 .service-selector__grid .service-option {
   height: 100%;
   scroll-snap-align: start;

--- a/assets/css/components/detail.css
+++ b/assets/css/components/detail.css
@@ -1,3 +1,26 @@
+.detail-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 24px;
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 12px;
+}
+
+.detail-card header .eyebrow {
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.detail-card header h3 {
+  margin: 4px 0;
+}
+
+.detail-card p {
+  margin: 0;
   color: var(--muted);
 }
 

--- a/assets/css/components/legal.css
+++ b/assets/css/components/legal.css
@@ -1,8 +1,3 @@
-  box-shadow: var(--shadow);
-  display: grid;
-  gap: 12px;
-}
-
 .legal-page {
   display: grid;
   gap: 48px;
@@ -49,6 +44,8 @@
   border-radius: 18px;
   padding: 24px;
   box-shadow: var(--shadow);
+  display: grid;
+  gap: 12px;
 }
 
 .legal-contact__card h2 {
@@ -83,18 +80,3 @@
   .service-selector__grid {
     padding-right: 0;
   }
-}
-
-.detail-card header .eyebrow {
-  text-transform: uppercase;
-  font-size: 12px;
-  letter-spacing: 0.08em;
-  color: var(--muted);
-}
-
-.detail-card header h3 {
-  margin: 4px 0;
-}
-
-.detail-card p {
-  margin: 0;

--- a/assets/css/components/quote.css
+++ b/assets/css/components/quote.css
@@ -1,4 +1,3 @@
-}
 .quote-card-panel .quote-form select,
 .quote-card-panel .quote-form input[type="email"],
 .quote-card-panel .quote-form input[type="text"] {


### PR DESCRIPTION
## Summary
- restore the missing `.detail-card` wrapper styles so service detail layouts render as cards again
- clean up stray closing braces in the contact and quote stylesheets to prevent the browser from dropping form styling
- move the legal contact card spacing rules back into the legal stylesheet so the sidebar layout stays intact

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d8c557e4b48333ba10f1f8f4d00052